### PR TITLE
Additions to enable type checking of this as an import

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,3 +26,7 @@ install_requires =
 zip_safe = False
 include_package_data = True
 scripts = bin/piezo-predict.py
+
+
+[options.package_data]
+piezo = py.typed


### PR DESCRIPTION
This should enable `mypy` to run on `gnomonicus` as expected