### PR TITLE
Fix/minor default

### DIFF
--- a/piezo/grammar_GARC1.py
+++ b/piezo/grammar_GARC1.py
@@ -401,7 +401,10 @@ def predict_GARC1(
                 result[compound] = ("S", {})
             else:
                 raise ValueError(
-                    "No entry found in the catalogue for " + gene_mutation + " " + compound
+                    "No entry found in the catalogue for "
+                    + gene_mutation
+                    + " "
+                    + compound
                 )
         else:
             final_prediction: Tuple = predictions[sorted(predictions)[-1]]

--- a/tests/test_catalogue.py
+++ b/tests/test_catalogue.py
@@ -539,6 +539,5 @@ def test_misc():
     with pytest.raises(ValueError):
         print(test_catalogue.predict("M3@12_del_c"))
 
-    
     # Double checking that a minor allele doesn't hit a general rule anymore
     assert test_catalogue.predict("M2@37_del_c:0.2") == {"DRUG_A": "S", "DRUG_B": "S"}


### PR DESCRIPTION
Should ensure that `Rv0678@12_del_c:2` doesn't hit the rule `Rv0678@*_fs`, instead returning `S`